### PR TITLE
Make a CrudHandler interface public

### DIFF
--- a/library/src/main/java/com/getbase/android/db/provider/CrudHandler.java
+++ b/library/src/main/java/com/getbase/android/db/provider/CrudHandler.java
@@ -10,7 +10,7 @@ import android.os.RemoteException;
 
 import java.util.ArrayList;
 
-interface CrudHandler {
+public interface CrudHandler {
 
   public Cursor query(Uri url, String[] projection, String selection, String[] selectionArgs, String sortOrder) throws RemoteException;
 


### PR DESCRIPTION
Client applications should be able to define their own CrudHandler.
Take autoprovider's ContentUriHandlers as an example. You would
probably want to perform a ProviderAction on a single handler
someday (yeah, that's what just happened to me)